### PR TITLE
Add auth modal and profile drawer

### DIFF
--- a/src/lib/components/AuthModal.svelte
+++ b/src/lib/components/AuthModal.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+
+	export let open = false;
+	export let mode: 'login' | 'signup' = 'login';
+	export let onClose: () => void;
+
+	const dispatch = createEventDispatcher<{ complete: void; switch: { mode: 'login' | 'signup' } }>();
+
+	let name = '';
+	let email = '';
+	let password = '';
+
+	const handleSubmit = () => {
+		dispatch('complete');
+		name = '';
+		email = '';
+		password = '';
+	};
+</script>
+
+{#if open}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 p-6">
+		<div class="w-full max-w-md rounded-2xl border border-white/10 bg-slate-900 p-6 shadow-xl">
+			<div class="flex items-start justify-between gap-4">
+				<div>
+					<h3 class="text-lg font-semibold text-white">
+						{mode === 'login' ? 'Welcome back' : 'Create your account'}
+					</h3>
+					<p class="mt-2 text-sm text-slate-300">
+						{mode === 'login'
+							? 'Sign in to manage your bids, watchlist, and saved searches.'
+							: 'Join OpenLane to follow auctions and place real-time bids.'}
+					</p>
+				</div>
+				<button
+					class="text-slate-400 transition hover:text-white"
+					on:click={onClose}
+					aria-label="Close"
+				>
+					✕
+				</button>
+			</div>
+
+			<div class="mt-6 flex gap-2 rounded-full border border-white/10 bg-slate-950/60 p-1 text-xs text-slate-300">
+				<button
+					class={`flex-1 rounded-full px-3 py-1.5 font-semibold transition ${
+						mode === 'login' ? 'bg-white text-slate-900' : 'hover:text-white'
+					}`}
+					on:click={() => dispatch('switch', { mode: 'login' })}
+				>
+					Log in
+				</button>
+				<button
+					class={`flex-1 rounded-full px-3 py-1.5 font-semibold transition ${
+						mode === 'signup' ? 'bg-white text-slate-900' : 'hover:text-white'
+					}`}
+					on:click={() => dispatch('switch', { mode: 'signup' })}
+				>
+					Sign up
+				</button>
+			</div>
+
+			<div class="mt-6 flex flex-col gap-3">
+				{#if mode === 'signup'}
+					<div>
+						<label class="text-xs font-semibold uppercase tracking-wide text-slate-400">Full name</label>
+						<input
+							class="mt-2 w-full rounded-lg border border-white/10 bg-slate-900/60 px-4 py-2 text-sm text-white focus:border-brand focus:outline-none"
+							placeholder="Avery Johnson"
+							bind:value={name}
+							type="text"
+						/>
+					</div>
+				{/if}
+				<div>
+					<label class="text-xs font-semibold uppercase tracking-wide text-slate-400">Email address</label>
+					<input
+						class="mt-2 w-full rounded-lg border border-white/10 bg-slate-900/60 px-4 py-2 text-sm text-white focus:border-brand focus:outline-none"
+						placeholder="you@openlane.com"
+						bind:value={email}
+						type="email"
+					/>
+				</div>
+				<div>
+					<label class="text-xs font-semibold uppercase tracking-wide text-slate-400">Password</label>
+					<input
+						class="mt-2 w-full rounded-lg border border-white/10 bg-slate-900/60 px-4 py-2 text-sm text-white focus:border-brand focus:outline-none"
+						placeholder="••••••••"
+						bind:value={password}
+						type="password"
+					/>
+				</div>
+			</div>
+
+			<Button className="mt-6 w-full rounded-lg" variant="secondary" on:click={handleSubmit}>
+				{mode === 'login' ? 'Continue' : 'Create account'}
+			</Button>
+			<p class="mt-3 text-xs text-slate-400">
+				By continuing you agree to OpenLane terms and confirm you are 18 years or older.
+			</p>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/BidHistory.svelte
+++ b/src/lib/components/BidHistory.svelte
@@ -2,18 +2,31 @@
 	import Card from '$lib/components/ui/Card.svelte';
 
 	export let bids: { bidder: string; amount: number; time: string }[];
+	export let highlightIndex: number | null = null;
 </script>
 
 <Card>
 	<h3 class="text-sm font-semibold text-white">Bid history</h3>
 	<ul class="mt-4 space-y-3">
-		{#each bids as bid}
-			<li class="flex items-center justify-between text-sm text-slate-300">
+		{#each bids as bid, index}
+			<li
+				class={`flex items-center justify-between rounded-lg px-3 py-2 text-sm transition ${
+					highlightIndex === index
+						? 'bg-emerald-500/10 text-emerald-100 ring-1 ring-emerald-400/30'
+						: 'text-slate-300'
+				}`}
+			>
 				<div>
-					<p class="font-medium text-white">{bid.bidder}</p>
-					<p class="text-xs text-slate-500">{bid.time}</p>
+					<p class={highlightIndex === index ? 'font-semibold text-white' : 'font-medium text-white'}>
+						{bid.bidder}
+					</p>
+					<p class={highlightIndex === index ? 'text-xs text-emerald-200' : 'text-xs text-slate-500'}>
+						{bid.time}
+					</p>
 				</div>
-				<p class="font-semibold text-white">€{bid.amount.toLocaleString()}</p>
+				<p class={highlightIndex === index ? 'font-semibold text-emerald-100' : 'font-semibold text-white'}>
+					€{bid.amount.toLocaleString()}
+				</p>
 			</li>
 		{/each}
 	</ul>

--- a/src/lib/components/MediaGallery.svelte
+++ b/src/lib/components/MediaGallery.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	export let images: string[] = [];
+	let activeIndex = 0;
+
+	const select = (index: number) => {
+		activeIndex = index;
+	};
+</script>
+
+<div class="space-y-4">
+	<div class="overflow-hidden rounded-3xl border border-white/10 bg-white/5">
+		<img
+			class="h-80 w-full object-cover"
+			src={images[activeIndex]}
+			alt={`Gallery image ${activeIndex + 1}`}
+		/>
+	</div>
+	<div class="flex gap-3 overflow-x-auto pb-1">
+		{#each images as image, index}
+			<button
+				class={`h-16 w-24 flex-shrink-0 overflow-hidden rounded-xl border ${
+					index === activeIndex ? 'border-brand' : 'border-white/10'
+				}`}
+				on:click={() => select(index)}
+			>
+				<img class="h-full w-full object-cover" src={image} alt={`Thumbnail ${index + 1}`} />
+			</button>
+		{/each}
+	</div>
+</div>

--- a/src/lib/components/Navigation.svelte
+++ b/src/lib/components/Navigation.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import Button from '$lib/components/ui/Button.svelte';
+	import AuthModal from '$lib/components/AuthModal.svelte';
+	import ProfileDrawer from '$lib/components/ProfileDrawer.svelte';
 
 	const links = [
 		{ label: 'Home', href: '/' },
@@ -7,6 +9,31 @@
 		{ label: 'Live Auctions', href: '/auctions/ol-gt500' },
 		{ label: 'How it works', href: '#how' }
 	];
+
+	let authModalOpen = false;
+	let authMode: 'login' | 'signup' = 'login';
+	let profileOpen = false;
+	let isAuthenticated = false;
+
+	const user = {
+		name: 'Avery Johnson',
+		email: 'avery@openlane.com'
+	};
+
+	const openAuth = (mode: 'login' | 'signup') => {
+		authMode = mode;
+		authModalOpen = true;
+	};
+
+	const handleAuthComplete = () => {
+		isAuthenticated = true;
+		authModalOpen = false;
+	};
+
+	const handleLogout = () => {
+		isAuthenticated = false;
+		profileOpen = false;
+	};
 </script>
 
 <header class="sticky top-0 z-40 border-b border-white/10 bg-slate-950/80 backdrop-blur">
@@ -21,8 +48,35 @@
 			{/each}
 		</nav>
 		<div class="flex items-center gap-3">
-			<Button variant="outline" size="sm">Log in</Button>
-			<Button variant="secondary" size="sm">Get started</Button>
+			{#if isAuthenticated}
+				<Button variant="ghost" size="sm" className="hidden md:inline-flex" on:click={() => (profileOpen = true)}>
+					Watchlist
+				</Button>
+				<button
+					class="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-sm font-semibold text-white transition hover:bg-white/20"
+					on:click={() => (profileOpen = true)}
+					aria-label="Open profile drawer"
+				>
+					AJ
+				</button>
+			{:else}
+				<Button variant="outline" size="sm" on:click={() => openAuth('login')}>Log in</Button>
+				<Button variant="secondary" size="sm" on:click={() => openAuth('signup')}>Get started</Button>
+			{/if}
 		</div>
 	</div>
+
+	<AuthModal
+		open={authModalOpen}
+		mode={authMode}
+		onClose={() => (authModalOpen = false)}
+		on:complete={handleAuthComplete}
+		on:switch={(event) => (authMode = event.detail.mode)}
+	/>
+	<ProfileDrawer
+		open={profileOpen}
+		{user}
+		onClose={() => (profileOpen = false)}
+		on:logout={handleLogout}
+	/>
 </header>

--- a/src/lib/components/ProfileDrawer.svelte
+++ b/src/lib/components/ProfileDrawer.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+
+	export let open = false;
+	export let user: { name: string; email: string } = { name: 'Guest', email: 'guest@openlane.com' };
+	export let onClose: () => void;
+
+	const dispatch = createEventDispatcher<{ logout: void }>();
+</script>
+
+{#if open}
+	<div class="fixed inset-0 z-40 bg-slate-950/70" on:click={onClose} aria-hidden="true"></div>
+	<aside
+		class="fixed right-0 top-0 z-50 flex h-full w-full max-w-sm flex-col border-l border-white/10 bg-slate-950 p-6 shadow-2xl"
+	>
+		<div class="flex items-start justify-between">
+			<div>
+				<p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Signed in as</p>
+				<h3 class="mt-2 text-lg font-semibold text-white">{user.name}</h3>
+				<p class="text-sm text-slate-400">{user.email}</p>
+			</div>
+			<button class="text-slate-400 transition hover:text-white" on:click={onClose} aria-label="Close">
+				✕
+			</button>
+		</div>
+
+		<div class="mt-8 grid gap-4">
+			<div class="rounded-xl border border-white/10 bg-slate-900/60 p-4">
+				<p class="text-xs uppercase tracking-wide text-slate-400">Watchlist</p>
+				<p class="mt-2 text-sm text-white">2 active lots saved</p>
+				<p class="mt-2 text-xs text-slate-400">Add vehicles to track price movement and auction alerts.</p>
+			</div>
+			<div class="rounded-xl border border-white/10 bg-slate-900/60 p-4">
+				<p class="text-xs uppercase tracking-wide text-slate-400">Bids</p>
+				<p class="mt-2 text-sm text-white">1 live bid · 3 past bids</p>
+				<p class="mt-2 text-xs text-slate-400">Review bid status and manage automatic increments.</p>
+			</div>
+			<div class="rounded-xl border border-white/10 bg-slate-900/60 p-4">
+				<p class="text-xs uppercase tracking-wide text-slate-400">Upcoming auctions</p>
+				<p class="mt-2 text-sm text-white">Next preview: Friday at 11:00 CET</p>
+				<p class="mt-2 text-xs text-slate-400">Receive reminders before bidding windows open.</p>
+			</div>
+		</div>
+
+		<div class="mt-auto space-y-3">
+			<Button className="w-full rounded-lg" variant="outline" on:click={onClose}>
+				Account settings
+			</Button>
+			<Button className="w-full rounded-lg" variant="ghost" on:click={() => dispatch('logout')}>
+				Log out
+			</Button>
+		</div>
+	</aside>
+{/if}

--- a/src/lib/components/ui/Tabs.svelte
+++ b/src/lib/components/ui/Tabs.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	export let tabs: { id: string; label: string }[] = [];
+	export let active: string;
+	export let onChange: (id: string) => void;
+</script>
+
+<div class="flex flex-wrap gap-2">
+	{#each tabs as tab}
+		<button
+			class={`rounded-full px-4 py-2 text-xs font-semibold transition ${
+				active === tab.id ? 'bg-white text-slate-900' : 'border border-white/15 text-white/70'
+			}`}
+			on:click={() => onChange(tab.id)}
+		>
+			{tab.label}
+		</button>
+	{/each}
+</div>

--- a/src/lib/data/cars.ts
+++ b/src/lib/data/cars.ts
@@ -8,6 +8,7 @@ export type Car = {
 	fuel: 'Gasoline' | 'Hybrid' | 'Electric';
 	transmission: 'Automatic' | 'Manual';
 	image: string;
+	gallery: string[];
 	status: 'Live' | 'Upcoming' | 'Closed';
 	rating: number;
 	bids: number;
@@ -26,6 +27,11 @@ export const cars: Car[] = [
 		transmission: 'Automatic',
 		image:
 			'https://images.unsplash.com/photo-1503376780353-7e6692767b70?auto=format&fit=crop&w=1400&q=80',
+		gallery: [
+			'https://images.unsplash.com/photo-1503376780353-7e6692767b70?auto=format&fit=crop&w=1400&q=80',
+			'https://images.unsplash.com/photo-1503736334956-4c8f8e92946d?auto=format&fit=crop&w=1400&q=80',
+			'https://images.unsplash.com/photo-1493238792000-8113da705763?auto=format&fit=crop&w=1400&q=80'
+		],
 		status: 'Live',
 		rating: 4.9,
 		bids: 18,
@@ -42,6 +48,11 @@ export const cars: Car[] = [
 		transmission: 'Automatic',
 		image:
 			'https://images.unsplash.com/photo-1502877338535-766e1452684a?auto=format&fit=crop&w=1400&q=80',
+		gallery: [
+			'https://images.unsplash.com/photo-1502877338535-766e1452684a?auto=format&fit=crop&w=1400&q=80',
+			'https://images.unsplash.com/photo-1511919884226-fd3cad34687c?auto=format&fit=crop&w=1400&q=80',
+			'https://images.unsplash.com/photo-1494976388531-d1058494cdd8?auto=format&fit=crop&w=1400&q=80'
+		],
 		status: 'Live',
 		rating: 4.8,
 		bids: 24,
@@ -58,6 +69,11 @@ export const cars: Car[] = [
 		transmission: 'Automatic',
 		image:
 			'https://images.unsplash.com/photo-1493238792000-8113da705763?auto=format&fit=crop&w=1400&q=80',
+		gallery: [
+			'https://images.unsplash.com/photo-1493238792000-8113da705763?auto=format&fit=crop&w=1400&q=80',
+			'https://images.unsplash.com/photo-1502877338535-766e1452684a?auto=format&fit=crop&w=1400&q=80',
+			'https://images.unsplash.com/photo-1503736334956-4c8f8e92946d?auto=format&fit=crop&w=1400&q=80'
+		],
 		status: 'Upcoming',
 		rating: 4.7,
 		bids: 9,
@@ -74,6 +90,11 @@ export const cars: Car[] = [
 		transmission: 'Automatic',
 		image:
 			'https://images.unsplash.com/photo-1507136566006-cfc505b114fc?auto=format&fit=crop&w=1400&q=80',
+		gallery: [
+			'https://images.unsplash.com/photo-1507136566006-cfc505b114fc?auto=format&fit=crop&w=1400&q=80',
+			'https://images.unsplash.com/photo-1503376780353-7e6692767b70?auto=format&fit=crop&w=1400&q=80',
+			'https://images.unsplash.com/photo-1502877338535-766e1452684a?auto=format&fit=crop&w=1400&q=80'
+		],
 		status: 'Live',
 		rating: 4.6,
 		bids: 16,
@@ -90,6 +111,11 @@ export const cars: Car[] = [
 		transmission: 'Manual',
 		image:
 			'https://images.unsplash.com/photo-1487754180451-c456f719a1fc?auto=format&fit=crop&w=1400&q=80',
+		gallery: [
+			'https://images.unsplash.com/photo-1487754180451-c456f719a1fc?auto=format&fit=crop&w=1400&q=80',
+			'https://images.unsplash.com/photo-1503376780353-7e6692767b70?auto=format&fit=crop&w=1400&q=80',
+			'https://images.unsplash.com/photo-1494976388531-d1058494cdd8?auto=format&fit=crop&w=1400&q=80'
+		],
 		status: 'Closed',
 		rating: 4.5,
 		bids: 22,
@@ -106,6 +132,11 @@ export const cars: Car[] = [
 		transmission: 'Automatic',
 		image:
 			'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1400&q=80',
+		gallery: [
+			'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1400&q=80',
+			'https://images.unsplash.com/photo-1502877338535-766e1452684a?auto=format&fit=crop&w=1400&q=80',
+			'https://images.unsplash.com/photo-1507136566006-cfc505b114fc?auto=format&fit=crop&w=1400&q=80'
+		],
 		status: 'Upcoming',
 		rating: 4.8,
 		bids: 11,

--- a/src/routes/auctions/[id]/+page.svelte
+++ b/src/routes/auctions/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import { onMount } from 'svelte';
 	import BidForm from '$lib/components/BidForm.svelte';
 	import BidHistory from '$lib/components/BidHistory.svelte';
 	import Countdown from '$lib/components/Countdown.svelte';
@@ -13,6 +14,10 @@
 	let showModal = false;
 	let latestBid = 0;
 	let activeTab = 'overview';
+	let currentBid = 0;
+	let liveBids = [...bidHistory];
+	let highlightCurrentBid = false;
+	let highlightIndex: number | null = null;
 
 	const tabOptions = [
 		{ id: 'overview', label: 'Overview' },
@@ -20,12 +25,52 @@
 		{ id: 'history', label: 'History' }
 	];
 
+	const bidders = [
+		'DriveMax Capital',
+		'Apex Auto Fund',
+		'Velocity Collective',
+		'Nordic Motors',
+		'Summit Auto Group',
+		'Atlas Performance',
+		'Valencia Classics'
+	];
+
 	$: car = cars.find((item) => item.id === $page.params.id) ?? cars[0];
+	$: currentBid = currentBid || car.priceEstimate - 4500;
 
 	const handleBid = (amount: number) => {
 		latestBid = amount;
 		showModal = true;
 	};
+
+	const pulseHighlights = () => {
+		highlightCurrentBid = true;
+		highlightIndex = 0;
+		setTimeout(() => {
+			highlightCurrentBid = false;
+			highlightIndex = null;
+		}, 1400);
+	};
+
+	onMount(() => {
+		currentBid = car.priceEstimate - 4500;
+		const interval = setInterval(() => {
+			const increment = 1000 * (1 + Math.floor(Math.random() * 3));
+			const nextBid = currentBid + increment;
+			const bidder = bidders[Math.floor(Math.random() * bidders.length)];
+			const nextEntry = {
+				bidder,
+				amount: nextBid,
+				time: 'Just now'
+			};
+
+			currentBid = nextBid;
+			liveBids = [nextEntry, ...liveBids].slice(0, 5);
+			pulseHighlights();
+		}, 5200);
+
+		return () => clearInterval(interval);
+	});
 </script>
 
 <section class="mx-auto w-full max-w-6xl px-6 py-16">
@@ -105,7 +150,15 @@
 				<div class="mt-4 space-y-3 text-sm text-slate-300">
 					<div class="flex items-center justify-between">
 						<span>Current bid</span>
-						<span class="text-lg font-semibold text-white">€{(car.priceEstimate - 4500).toLocaleString()}</span>
+						<span
+							class={`text-lg font-semibold transition ${
+								highlightCurrentBid
+									? 'text-emerald-100 drop-shadow-[0_0_10px_rgba(16,185,129,0.6)]'
+									: 'text-white'
+							}`}
+						>
+							€{currentBid.toLocaleString()}
+						</span>
 					</div>
 					<div class="flex items-center justify-between">
 						<span>Bid increment</span>
@@ -118,7 +171,7 @@
 				</div>
 			</Card>
 			<BidForm on:submit={(e) => handleBid(e.detail)} />
-			<BidHistory bids={bidHistory} />
+			<BidHistory bids={liveBids} highlightIndex={highlightIndex} />
 		</div>
 	</div>
 </section>

--- a/src/routes/auctions/[id]/+page.svelte
+++ b/src/routes/auctions/[id]/+page.svelte
@@ -3,13 +3,22 @@
 	import BidForm from '$lib/components/BidForm.svelte';
 	import BidHistory from '$lib/components/BidHistory.svelte';
 	import Countdown from '$lib/components/Countdown.svelte';
+	import MediaGallery from '$lib/components/MediaGallery.svelte';
 	import Modal from '$lib/components/Modal.svelte';
 	import Badge from '$lib/components/ui/Badge.svelte';
 	import Card from '$lib/components/ui/Card.svelte';
+	import Tabs from '$lib/components/ui/Tabs.svelte';
 	import { bidHistory, cars } from '$lib/data/cars';
 
 	let showModal = false;
 	let latestBid = 0;
+	let activeTab = 'overview';
+
+	const tabOptions = [
+		{ id: 'overview', label: 'Overview' },
+		{ id: 'specs', label: 'Specs' },
+		{ id: 'history', label: 'History' }
+	];
 
 	$: car = cars.find((item) => item.id === $page.params.id) ?? cars[0];
 
@@ -22,7 +31,7 @@
 <section class="mx-auto w-full max-w-6xl px-6 py-16">
 	<div class="grid gap-10 lg:grid-cols-[1.1fr_0.9fr]">
 		<div class="space-y-6">
-			<img src={car.image} alt={car.name} class="h-80 w-full rounded-3xl object-cover" />
+			<MediaGallery images={car.gallery} />
 			<Card>
 				<div class="flex flex-wrap items-center justify-between gap-4">
 					<div>
@@ -53,10 +62,40 @@
 						<p class="mt-2 text-lg font-semibold text-white">{car.transmission}</p>
 					</Card>
 				</div>
-				<p class="mt-6 text-sm text-slate-400">
-					This listing includes full inspection reports, service history, and a dedicated OpenLane concierge.
-					Schedule a private walkthrough or request additional photos with one click.
-				</p>
+				<div class="mt-8 space-y-4">
+					<Tabs tabs={tabOptions} active={activeTab} onChange={(id) => (activeTab = id)} />
+					{#if activeTab === 'overview'}
+						<p class="text-sm text-slate-400">
+							This listing includes full inspection reports, service history, and a dedicated OpenLane
+							concierge. Schedule a private walkthrough or request additional photos with one click.
+						</p>
+					{:else if activeTab === 'specs'}
+						<div class="grid gap-3 text-sm text-slate-300">
+							<div class="flex items-center justify-between">
+								<span>Drivetrain</span>
+								<span class="text-white">AWD Performance</span>
+							</div>
+							<div class="flex items-center justify-between">
+								<span>Horsepower</span>
+								<span class="text-white">720 hp</span>
+							</div>
+							<div class="flex items-center justify-between">
+								<span>0-100 km/h</span>
+								<span class="text-white">3.1s</span>
+							</div>
+							<div class="flex items-center justify-between">
+								<span>Top speed</span>
+								<span class="text-white">320 km/h</span>
+							</div>
+						</div>
+					{:else}
+						<ul class="space-y-3 text-sm text-slate-400">
+							<li>2024-11-14 — Full inspection completed (OpenLane certified)</li>
+							<li>2024-07-05 — Ceramic coating applied, interior refreshed</li>
+							<li>2024-03-19 — Major service completed at authorized dealer</li>
+						</ul>
+					{/if}
+				</div>
 			</Card>
 		</div>
 


### PR DESCRIPTION
## Summary
- add auth modal with login/signup views
- add profile drawer with watchlist/bids placeholders
- update header to reflect auth state and open modals/drawer

## Testing
- not run (UI only)